### PR TITLE
Minor fix to resolve generated page URLs to match repo casing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "jekyll", "~> 4.3.3"
 
-gem "just-the-docs", "~> 0.7.0"
+gem "minima", "~> 2.5"
 
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
@@ -22,3 +22,5 @@ gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 # Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
 # do not have a Java counterpart.
 gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]
+
+gem "just-the-docs", "~> 0.7.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,10 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
+    minima (2.5.1)
+      jekyll (>= 3.5, < 5.0)
+      jekyll-feed (~> 0.9)
+      jekyll-seo-tag (~> 2.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (5.0.4)
@@ -66,6 +70,21 @@ GEM
     rexml (3.2.6)
     rouge (4.2.0)
     safe_yaml (1.0.5)
+    sass-embedded (1.70.0)
+      google-protobuf (~> 3.25)
+      rake (>= 13.0.0)
+    sass-embedded (1.70.0-aarch64-linux-android)
+      google-protobuf (~> 3.25)
+    sass-embedded (1.70.0-arm-linux-androideabi)
+      google-protobuf (~> 3.25)
+    sass-embedded (1.70.0-arm-linux-gnueabihf)
+      google-protobuf (~> 3.25)
+    sass-embedded (1.70.0-arm-linux-musleabihf)
+      google-protobuf (~> 3.25)
+    sass-embedded (1.70.0-x86-linux-android)
+      google-protobuf (~> 3.25)
+    sass-embedded (1.70.0-x86_64-linux-android)
+      google-protobuf (~> 3.25)
     sass-embedded (1.70.0-x86_64-linux-gnu)
       google-protobuf (~> 3.25)
     terminal-table (3.0.2)
@@ -74,7 +93,14 @@ GEM
     webrick (1.8.1)
 
 PLATFORMS
-  x86_64-linux-gnu
+  aarch64-linux-android
+  arm-linux-androideabi
+  arm-linux-gnueabihf
+  arm-linux-musleabihf
+  ruby
+  x86-linux-android
+  x86_64-linux
+  x86_64-linux-android
 
 DEPENDENCIES
   http_parser.rb (~> 0.6.0)
@@ -82,6 +108,7 @@ DEPENDENCIES
   jekyll-feed (~> 0.12)
   jekyll-paginate (~> 1.1)
   just-the-docs (~> 0.7.0)
+  minima (~> 2.5)
   tzinfo (>= 1, < 3)
   tzinfo-data
   wdm (~> 0.1.1)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Assuming [Ruby 3.3](https://github.com/rbenv/rbenv), [Bundler, and Jekyll](https
 1. Change your working directory to the root of this repository.
 2. Run `bundle` to install all necessary dependencies.
 3. Run `./run.sh` to build the guide site and start the Jekyll server.
-4. Preview the guide at `http://localhost:4000/ai-in-production-guide/`.
+4. Preview the guide at `http://localhost:4000/AI-in-Production-Guide/`.
 
 The built site is stored in the directory `_site`.
 

--- a/_config.local.yml
+++ b/_config.local.yml
@@ -1,9 +1,9 @@
 # Config for GitHub Pages
 theme: just-the-docs
 
-# ========================================================
-# == everything below is the same as _config.local.yaml ==
-# ========================================================
+# ==================================================
+# == everything below is the same as _config.yaml ==
+# ==================================================
 
 title: AI in Production Guide
 description: >-
@@ -11,7 +11,7 @@ description: >-
   technical professionals venturing into the world of artificial intelligence
   with Azure. It aims to demystify the process of AI project development and
   provide a smooth transition of AI workloads into a production environment.
-baseurl: "/ai-in-production-guide"
+baseurl: "/AI-in-Production-Guide"
 url: ""
 
 favicon_ico: "/media/favicon.png"

--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ description: >-
   technical professionals venturing into the world of artificial intelligence
   with Azure. It aims to demystify the process of AI project development and
   provide a smooth transition of AI workloads into a production environment.
-baseurl: "/ai-in-production-guide"
+baseurl: "/AI-in-Production-Guide"
 url: ""
 
 favicon_ico: "/media/favicon.png"

--- a/run.sh
+++ b/run.sh
@@ -1,1 +1,1 @@
-bundle exec jekyll serve --config _config.local.yml --baseurl="/ai-in-production-guide" --host localhost --port 4000 --livereload
+bundle exec jekyll serve --config _config.local.yml --baseurl="/AI-in-Production-Guide" --host localhost --port 4000 --livereload


### PR DESCRIPTION
This change includes a minor change to resolve the rendering of the GitHub pages site at https://soferreira.github.io/AI-in-Production-Guide