### PR TITLE
Add table of contents component include and update all pages

### DIFF
--- a/_includes/table_of_contents.md
+++ b/_includes/table_of_contents.md
@@ -1,0 +1,10 @@
+<details open markdown="block">
+  <summary>
+    In this chapter
+  </summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>
+
+{::options toc_levels="2..4" /}

--- a/chapters/chapter_01_setting_off_understanding_ai_landscape.md
+++ b/chapters/chapter_01_setting_off_understanding_ai_landscape.md
@@ -8,20 +8,13 @@ layout: default
 
 # Chapter 1: Setting Off: Understanding AI's Landscape
 
+{% include table_of_contents.md %}
+
 Welcome to the first chapter of "AI Lifecycle Mastery: From Concept to Reality – Navigating Successful AI Deployments." As we start on this journey together, this chapter will be your guide to understanding the comprehensive AI capabilities of Azure. Whether you are a technical practitioner seeking in-depth knowledge, a business leader exploring the strategic aspects of AI, or a project manager focused on effective coordination and implementation, this guide is tailored to your needs.
 
 In this chapter, we examine the complexities of Azure's AI ecosystem. We will highlight Azure AI services, including Azure OpenAI and Azure Machine Learning, setting the stage for a deeper exploration into practical AI deployment strategies within your organization. Join us as we navigate through the intricacies of Azure's AI tools and services, paving the way for a successful and informed AI integration.
 
 ![Setting Off: Understanding AIs Landscape](./../media/chapter1.jpg)
-
-<details open markdown="block">
-  <summary>
-    Table of contents
-  </summary>
-  {: .text-delta }
-1. TOC
-{:toc}
-</details>
 
 **Further Reading on AI History**: For those interested in the historical evolution of AI, these resources offer a deeper dive.
 

--- a/chapters/chapter_02_charting_course_ideation_goal_setting.md
+++ b/chapters/chapter_02_charting_course_ideation_goal_setting.md
@@ -8,18 +8,11 @@ layout: default
 
 # Chapter 2: Charting the Course: Ideation and Goal Setting
 
+{% include table_of_contents.md %}
+
 In this chapter, we explore the vital process of ideation and goal setting in AI projects. These initial stages are crucial in shaping the direction, feasibility, and alignment of AI initiatives with business objectives. Understanding these early stages deeply impacts the success of AI projects. This chapter provides comprehensive insights and resources to navigate this critical phase effectively.
 
 ![Charting the Course: Ideation and Goal Setting](./../media/chapter2.jpg)
-
-<details open markdown="block">
-  <summary>
-    Table of contents
-  </summary>
-  {: .text-delta }
-1. TOC
-{:toc}
-</details>
 
 ## Foundational Insights and Resources
 

--- a/chapters/chapter_03_gathering_your_crew_building_right_team.md
+++ b/chapters/chapter_03_gathering_your_crew_building_right_team.md
@@ -8,18 +8,11 @@ layout: default
 
 # Chapter 3: Gathering Your Crew: Building the Right Team
 
+{% include table_of_contents.md %}
+
 Welcome to the dynamic world of AI team building, a crucial step in our journey. On this chapter, we aim to equip you with the knowledge and insights necessary for assembling a team that not only possesses technical acumen but also embodies ethical understanding, diversity, and a strong sense of collaboration. We'll navigate the critical aspects of creating an AI dream team, focusing on the innovative, responsible, and efficient handling of AI projects.
 
 ![Gathering Your Crew: Building the Right Team](./../media/chapter3.jpg)
-
-<details open markdown="block">
-  <summary>
-    Table of contents
-  </summary>
-  {: .text-delta }
-1. TOC
-{:toc}
-</details>
 
 - **Constructing an AI Development Team**: ["How to Build an AI Development Team"](https://newxel.com/blog/how-to-build-an-ai-development-team/) from Newxel provides insightful guidance for businesses aiming to form an AI development team. The article focuses on the advantages, key roles, and steps necessary to build a team adept in AI solutions. It also compares the benefits and drawbacks of choosing either a dedicated team of remote AI developers or an in-house team of full-time employees. Additionally, it discusses the cost implications associated with each model, highlighting that a dedicated team might offer more cost-effectiveness and flexibility, which is particularly relevant for companies venturing into AI technology.
 

--- a/chapters/chapter_04_mapping_terrain_data_management_ethics.md
+++ b/chapters/chapter_04_mapping_terrain_data_management_ethics.md
@@ -8,18 +8,11 @@ layout: default
 
 # Chapter 4: Mapping the Terrain: Data Management and Ethics
 
+{% include table_of_contents.md %}
+
 In this chapter we delve into the crux of any AI project - the data. No AI can function without data, making data management a critical step in the AI lifecycle. However, handling data isn't just about collection and storage. It is a multidimensional process with ethical implications. In this chapter, we aim to provide a comprehensive guide on managing data effectively and ethically with a focus on AI.
 
 ![Mapping the Terrain: Data Management and Ethics](./../media/chapter4.jpg)
-
-<details open markdown="block">
-  <summary>
-    Table of contents
-  </summary>
-  {: .text-delta }
-1. TOC
-{:toc}
-</details>
 
 ## Understanding Data Management
 

--- a/chapters/chapter_05_crafting_vessel_design_development.md
+++ b/chapters/chapter_05_crafting_vessel_design_development.md
@@ -8,6 +8,8 @@ layout: default
 
 # Chapter 5: Crafting the Vessel: Design and Development
 
+{% include table_of_contents.md %}
+
 This chapter is dedicated to the design and development phase of AI projects, a specialized area within the broader scope of software development. While fundamentally software endeavors, AI-driven projects introduce unique challenges and demand specific methodologies, tools, and best practices.
 
 Our goal in this chapter is to guide you through these distinct aspects, showing how to effectively turn AI concepts into functional and robust solutions. We focus particularly on employing Azure's tools and services to support this journey.
@@ -15,15 +17,6 @@ Our goal in this chapter is to guide you through these distinct aspects, showing
 Given the comprehensive content, we've organized this chapter to both address the unique demands of AI development and highlight the practical application of Azure’s capabilities, aiming to provide a thorough yet accessible guide to navigating the complexities involved.
 
 ![Crafting the Vessel: Design and Development](./../media/chapter5.jpg)
-
-<details open markdown="block">
-  <summary>
-    Table of contents
-  </summary>
-  {: .text-delta }
-1. TOC
-{:toc}
-</details>
 
 AI-driven projects, although a subset of software projects, diverge significantly in their approach. They are characterized by a data-centric nature, iterative model development and training, and an emphasis on continuous learning and adaptation. To better understand these differences, let's begin with a comparative table that highlights the key contrasts between AI-driven and traditional software development:
 

--- a/chapters/chapter_06_testing_waters_testing_iteration.md
+++ b/chapters/chapter_06_testing_waters_testing_iteration.md
@@ -8,18 +8,11 @@ layout: default
 
 # Chapter 6: Testing the Waters: Testing and Iteration
 
+{% include table_of_contents.md %}
+
 Testing in AI projects is a pivotal process that differs significantly from traditional software testing methodologies. While the core goal of ensuring functionality and reliability remains the same, the unique characteristics of AI systems demand specialized approaches. This section provides an overview of these differences, emphasizing the critical role that testing plays throughout the AI lifecycle.
 
 ![Testing the Waters: Testing and Iteration](./../media/chapter6_framework.jpg)
-
-<details open markdown="block">
-  <summary>
-    Table of contents
-  </summary>
-  {: .text-delta }
-1. TOC
-{:toc}
-</details>
 
 ## Comparing Testing in AI Projects vs. Non-AI Software Testing
 

--- a/chapters/chapter_07_navigating_rough_seas_performance.md
+++ b/chapters/chapter_07_navigating_rough_seas_performance.md
@@ -8,18 +8,11 @@ layout: default
 
 # Chapter 7: Navigating Rough Seas: Performance
 
+{% include table_of_contents.md %}
+
 This chapter navigates the complex yet crucial aspects of AI performance, addressing both theoretical and practical dimensions. As AI continues to integrate into diverse sectors, understanding and optimizing its performance is imperative. We embark on a journey through various facets of AI performance, exploring metrics, benchmarking, optimization techniques, and post-deployment challenges.
 
 ![Navigating Rough Seas: Performance](./../media/chapter7.jpg)
-
-<details open markdown="block">
-  <summary>
-    Table of contents
-  </summary>
-  {: .text-delta }
-1. TOC
-{:toc}
-</details>
 
 ## Understanding AI Performance Metrics
 

--- a/chapters/chapter_08_securing_cargo_networking_security.md
+++ b/chapters/chapter_08_securing_cargo_networking_security.md
@@ -8,18 +8,11 @@ layout: default
 
 # Chapter 8: Securing the Cargo: Networking and Security
 
+{% include table_of_contents.md %}
+
 Networking and security are two critical aspects that need to be addressed early in the design and development of AI solutions to ensure their smooth functioning. By adopting networking and security in their Azure AI solutions, readers can ensure that their applications are secure, reliable, and trustworthy. This chapter offers readers the guidance to create and manage secure AI applications that align with their organization's values and well-established cybersecurity practices.
 
 ![Securing the Cargo: Networking and Security](./../media/chapter8.jpg)
-
-<details open markdown="block">
-  <summary>
-    Table of contents
-  </summary>
-  {: .text-delta }
-1. TOC
-{:toc}
-</details>
 
 ## Unique Challenges in AI Projects
 

--- a/chapters/chapter_09_managing_expedition_cost_management_optimization.md
+++ b/chapters/chapter_09_managing_expedition_cost_management_optimization.md
@@ -8,18 +8,11 @@ layout: default
 
 # Chapter 9: Managing the Expedition: Cost Management and Optimization
 
+{% include table_of_contents.md %}
+
 Managing the financial aspects of AI projects is as crucial as the technological innovations that drive them. This chapter serves as a navigational chart through the often turbulent waters of budgeting, cost management, and resource optimization in AI endeavors. It underscores the pivotal role of astute financial planning and cost control in ensuring the successful deployment and sustainability of AI solutions. Recognized as a unique challenge, distinct from traditional software projects, AI cost management demands a nuanced understanding of the specific cost drivers and efficient resource utilization strategies. As we embark on this journey, we delve into the intricate balance of cost, performance, and efficiency, providing insights and tools to master the art of cost management in the dynamic realm of AI projects.
 
 ![Managing the Expedition: Cost Management and Optimization](./../media/chapter9.jpg)
-
-<details open markdown="block">
-  <summary>
-    Table of contents
-  </summary>
-  {: .text-delta }
-1. TOC
-{:toc}
-</details>
 
 ## Key aspects of cost management in AI projects
 

--- a/chapters/chapter_10_weatherproofing_journey_reliability_high_availability.md
+++ b/chapters/chapter_10_weatherproofing_journey_reliability_high_availability.md
@@ -8,18 +8,11 @@ layout: default
 
 # Chapter 10: Weatherproofing the Journey: Reliability and High Availability
 
-In this section, we delve into the crucial aspects of reliability and high availability, which are essential for any production system, particularly AI solutions utilizing large language models (LLMs). We will provide resources and best practices for building resilient AI systems, focusing on strategies to enhance system availability. This includes exploring effective methods for load balancing requests, implementing failover mechanisms to healthy instances, and establishing robust recovery protocols from failures. Our goal is to equip you with the knowledge and tools necessary to ensure your AI systems are not only reliable but also consistently available, thereby optimizing their performance and utility in real-world applications.
+{% include table_of_contents.md %}
+
+In this chapter, we delve into the crucial aspects of reliability and high availability, which are essential for any production system, particularly AI solutions utilizing large language models (LLMs). We will provide resources and best practices for building resilient AI systems, focusing on strategies to enhance system availability. This includes exploring effective methods for load balancing requests, implementing failover mechanisms to healthy instances, and establishing robust recovery protocols from failures. Our goal is to equip you with the knowledge and tools necessary to ensure your AI systems are not only reliable but also consistently available, thereby optimizing their performance and utility in real-world applications.
 
 ![Weatherproofing the Journey: Reliability and High Availability](./../media/chapter10.jpg)
-
-<details open markdown="block">
-  <summary>
-    Table of contents
-  </summary>
-  {: .text-delta }
-1. TOC
-{:toc}
-</details>
 
 ## Importance of building resilient AI solutions
 

--- a/chapters/chapter_11_expanding_horizons_scaling_quota_management.md
+++ b/chapters/chapter_11_expanding_horizons_scaling_quota_management.md
@@ -8,18 +8,11 @@ layout: default
 
 # Chapter 11: Expanding Horizons: Scaling and Quota Management
 
+{% include table_of_contents.md %}
+
 In the ever-evolving landscape of AI, the ability to scale solutions efficiently and manage quotas for managed services effectively is critical. In this chapter, we delve into techniques for expanding the horizons of your AI applications, ensuring they not only meet the growing demands of your customers but do so with strategic foresight.
 
 ![Expanding Horizons: Scaling and Quota Management](./../media/chapter11.jpeg)
-
-<details open markdown="block">
-  <summary>
-    Table of contents
-  </summary>
-  {: .text-delta }
-1. TOC
-{:toc}
-</details>
 
 ## Scaling Azure AI solutions for optimal performance
 

--- a/chapters/chapter_12_keeping_log_observability.md
+++ b/chapters/chapter_12_keeping_log_observability.md
@@ -8,18 +8,11 @@ layout: default
 
 # Chapter 12: Keeping a Log: Observability
 
+{% include table_of_contents.md %}
+
 In this chapter, we delve into the fascinating world of observability in the context of Artificial Intelligence (AI). Observability, a term borrowed from control theory, is the ability to infer the internal states of a system based on its external outputs. In the realm of AI, observability takes on a new dimension as we strive to understand and interpret the behavior of complex AI models. From generative AI to predictive Machine Learning (ML), each AI model presents unique challenges and opportunities for observability. We will also explore how Azure services can be leveraged for AI observability.
 
 ![Keeping a Log: Observability](./../media/chapter12.jpg)
-
-<details open markdown="block">
-  <summary>
-    Table of contents
-  </summary>
-  {: .text-delta }
-1. TOC
-{:toc}
-</details>
 
 ## What is Observability?
 

--- a/chapters/chapter_13_building_for_everyone_multitenant_architecture.md
+++ b/chapters/chapter_13_building_for_everyone_multitenant_architecture.md
@@ -8,6 +8,8 @@ layout: default
 
 # Chapter 13: Building for Everyone: Multitenant Architecture
 
+{% include table_of_contents.md %}
+
 A multitenant solution refers to a single software application that is utilized by multiple customers, also known as tenants. It's important to distinguish between tenants and users; while users are individual accounts, a tenant represents a collective group of users from a single organization, company, or group.Examples of multitenant applications include:  
 
 Business-to-Business (B2B): multitenant solutions are often seen in software as a service (SaaS) products like accounting software and work tracking tools. These applications are shared among different businesses, each operating as a distinct tenant.
@@ -19,15 +21,6 @@ Enterprise-wide platform solutions: multitenant solutions can take the form of s
 When building your own multitenant solutions, there are several key architectural [considerations](https://learn.microsoft.com/azure/architecture/guide/multitenant/considerations/overview) that will influence your design, as well as different architectural [approaches](https://learn.microsoft.com/azure/architecture/guide/multitenant/approaches/overview).
 
 ![Building for Everyone: Multitenant Architecture](./../media/chapter13.jpg)
-
-<details open markdown="block">
-  <summary>
-    Table of contents
-  </summary>
-  {: .text-delta }
-1. TOC
-{:toc}
-</details>
 
 ## Architectural approaches for AI and ML in multitenant solutions
 

--- a/chapters/chapter_14_arrival_deployment_strategies.md
+++ b/chapters/chapter_14_arrival_deployment_strategies.md
@@ -8,18 +8,11 @@ layout: default
 
 # Chapter 14: Arrival: Deployment Strategies
 
+{% include table_of_contents.md %}
+
 As the landscape of AI-powered solutions transitions from being experimental to being a practical tool for customers, the strategies for deploying AI become increasingly more significant. Understanding how to efficiently deploy and manage these technologies on Azure is not just beneficial but necessary for staying competitive. This chapter delves into the ever-changing landscape of AI on Azure highlighting the importance of efficient, scalable, and secure deployment methods to maximize the success of AI applications with a global reach. It builds on the understanding of previous chapters on [design, development](./chapter_05_crafting_vessel_design_development), [testing](./chapter_06_testing_waters_testing_iteration), and [observability](./chapter_12_keeping_log_observability) to provide a comprehensive guide to the approaches for ensuring consistent delivery of AI solutions on Azure.
 
 ![Arrival: Deployment Strategies](./../media/chapter14.jpg)
-
-<details open markdown="block">
-  <summary>
-    Table of contents
-  </summary>
-  {: .text-delta }
-1. TOC
-{:toc}
-</details>
 
 ## Foundations of AI Deployment on Azure
 

--- a/chapters/chapter_15_continuing_voyage_monitoring_maintenance.md
+++ b/chapters/chapter_15_continuing_voyage_monitoring_maintenance.md
@@ -8,18 +8,11 @@ layout: default
 
 # Chapter 15: Continuing the Voyage: Monitoring and Maintenance
 
+{% include table_of_contents.md %}
+
 The effective use of AI Services services is not only just about implementation, it's also about continuous monitoring and maintenance. The importance of monitoring and maintenance in Azure AI services cannot be overstated. It ensures the smooth operation of AI applications, helps in identifying and rectifying issues promptly, and aids in optimizing performance over time. Moreover, it provides valuable insights into the system's behavior, which can be used to make informed decisions and strategic improvements.
 
 ![Continuing the Voyage: Monitoring and Maintenance](./../media/chapter15.jpg)
-
-<details open markdown="block">
-  <summary>
-    Table of contents
-  </summary>
-  {: .text-delta }
-1. TOC
-{:toc}
-</details>
 
 Here are some key elements of AI monitoring:
 


### PR DESCRIPTION
This change introduces a `table_of_contents.md` component include that has been updated across all pages. This will ensure that any future changes to the TOC doesn't need to be done per page. 

The change is to make the TOC consistent with other documentation where it is at the top of the article, only includes level 2+ headings, and reads as **In this chapter**

![image](https://github.com/soferreira/AI-in-Production-Guide/assets/13505183/2de4ebc2-125a-431d-a6c1-1f33ea57c056)
